### PR TITLE
fixed EIM message response timeout when start node_eim by local python

### DIFF
--- a/nodes_v3/node_eim.py
+++ b/nodes_v3/node_eim.py
@@ -1,5 +1,4 @@
 import time
-import os
 from loguru import logger
 from codelab_adapter_client import AdapterNode
 from codelab_adapter_client.utils import get_or_create_node_logger_dir
@@ -16,17 +15,18 @@ class EIMNode(AdapterNode):
     def __init__(self):
         super().__init__(logger=logger)
 
-    def send_message_to_scratch(self, content):
+    def _response_message_to_scratch(self, content, payload):
         message = self.message_template()
         message["payload"]["content"] = content
+        message["payload"]["message_id"] = payload.get('message_id')
         self.publish(message)
 
     def extension_message_handle(self, topic, payload):
-        self.logger.info(f'the message payload from scratch: {payload}')
+        self.logger.info(f'receive message from scratch, topic: {topic} payload: {payload}')
         content = payload["content"]
         if type(content) == str:
             content_send_to_scratch = content[::-1]  # 反转字符串
-            self.send_message_to_scratch(content_send_to_scratch)
+            self._response_message_to_scratch(content_send_to_scratch, payload)
 
     def run(self):
         i = 0


### PR DESCRIPTION
when adapter node response Scratch message, the value of  'message_id' should be equal the input payload['message_id'] 